### PR TITLE
Remove package gnome-shell-extension-coverflow-alt-tab

### DIFF
--- a/usr/share/bigbashview/bcc/apps/bigbashview-calamares/desktops/gnome/pkginstall.txt
+++ b/usr/share/bigbashview/bcc/apps/bigbashview-calamares/desktops/gnome/pkginstall.txt
@@ -36,7 +36,6 @@ gnome-session
 gnome-settings-daemon
 gnome-shell-extension-appindicator
 gnome-shell-extension-blur-my-shell
-gnome-shell-extension-coverflow-alt-tab
 gnome-shell-extension-dash-to-dock
 gnome-shell-extension-dash-to-panel
 gnome-shell-extension-gsconnect


### PR DESCRIPTION
Remove package gnome-shell-extension-coverflow-alt-tab